### PR TITLE
fix incorrect URL in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Common OWL/RDFS Vocabularies for use with Ruby [RDF.rb][]
 * RDF::Vocab::CC        - [Creative Commons Vocabulary](http://creativecommons.org/ns#) (Creative Commons) - Alias of `RDF::CC`
 * RDF::Vocab::CERT      - [Cert Ontology](http://www.w3.org/ns/auth/cert#) (W3C) - Alias of `RDF::CERT`
 * RDF::Vocab::CNT       - [Representing Content in RDF](http://www.w3.org/TR/Content-in-RDF10/) (W3C)
-* RDF::Vocab::DataCite  - [DataCite Ontology](http://bibframe.org/vocab/)
+* RDF::Vocab::DataCite  - [DataCite Ontology](http://purl.org/spar/datacite/)
 * RDF::Vocab::DC        - [DCMI Metadata Terms](http://purl.org/dc/terms/) (DCMI) - Alias of `RDF::DC`
 * RDF::Vocab::DC11      - [Dublin Core Metadata Element Set](http://purl.org/dc/elements/1.1/) (DCMI) - Alias of `RDF::DC11`
 * RDF::Vocab::DCAT      - [Data Catalog Vocabulary](http://www.w3.org/TR/vocab-dcat/) (DCMI) - Alias of `RDF::DCAT`


### PR DESCRIPTION
Resolves https://github.com/ruby-rdf/rdf-vocab/issues/5 with a correct URL for the DataCite ontology
