### PR TITLE
So we don't choke on blank nodes, check for presence of uri

### DIFF
--- a/lib/rdf/vocab/extensions.rb
+++ b/lib/rdf/vocab/extensions.rb
@@ -400,7 +400,7 @@ module RDF
         uncategorized = {}
         graph.query(predicate: RDF.type) do |statement|
           # Only serialize statements that are in the defined vocabulary
-          next unless statement.subject.start_with?(self.to_uri)
+          next unless statement.subject.uri? && statement.subject.start_with?(self.to_uri)
           case statement.object
           when RDF.Property,
                RDF::OWL.AnnotationProperty,


### PR DESCRIPTION
There is not an issue or test for this, as I thought it was a trivial fix. If you need me to do either or both, I'm happy to do so.

I know there are not many ontologies containing blank nodes, but there are a few (e.g. http://ontologi.es/doap-deps#).