### PR TITLE
gemspec: include VERSION in distributed gem

### DIFF
--- a/rdf-vocab.gemspec
+++ b/rdf-vocab.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |spec|
   spec.license       = "Unlicense"
 
   spec.platform      = Gem::Platform::RUBY
-  spec.files         = %w(README.md LICENSE) + Dir.glob('lib/**/*.rb')
+  spec.files         = %w(README.md LICENSE VERSION) + Dir.glob('lib/**/*.rb')
   spec.test_files    = Dir.glob('spec/*.rb')
   spec.require_paths = %w(lib)
   spec.has_rdoc      = false


### PR DESCRIPTION
Otherwise:
```
irb(main):002:0> RDF::Vocab::VERSION
Errno::ENOENT: No such file or directory @ rb_sysopen - /Users/alex/.rbenv/versions/2.4.2/lib/ruby/gems/2.4.0/gems/rdf-vocab-2.2.6/lib/rdf/vocab/../../../VERSION
        from (irb):2