### PR TITLE
require the exact path to vocabularies

### DIFF
--- a/lib/rdf/vocab.rb
+++ b/lib/rdf/vocab.rb
@@ -316,7 +316,7 @@ module RDF
     # Autoload vocabularies
     VOCABS.each do |id, params|
       v = params.fetch(:class_name, id.to_s.upcase).to_sym
-      autoload v, "rdf/vocab/#{id}" unless params[:alias]
+      autoload v, File.expand_path("../vocab/#{id}", __FILE__) unless params[:alias]
     end
 
     # Aliases for vocabularies still defined directly in RDF.rb


### PR DESCRIPTION
Due to quirks in Rails' autoloading behavior, currently some
vocabularies can fail to be loaded, leading to curious situations like
this:

```
irb(main):007:0> RDF::Vocab.constants
=> [:ICAL, :Identifiers, :IIIF, :JSONLD, :LRMI, :MA, :MADS, :MARCRelators, :MO, :MODS, :NFO, :GS1, :HT, :OG, :LDP, :ORE, :OGC, :OA, :ORG, :PPLAN, :PREMIS, :PremisEventType, :PROV, :PTR, :RightsStatements, :RSS, :SCHEMA, :SIOC, :SiocServices, :SKOS, :SKOSXL, :V, :VMD, :VCARD, :VOID, :VS, :WDRS, :WOT, :XKOS, :XHTML, :XHV, :VERSION, :VOCABS, :ACL, :BF2, :Bibframe, :CNT, :BIBO, :CC, :CERT, :CRM, :DataCite, :DC, :DC11, :DCMIType, :DISCO, :RSA, :DWC, :EBUCore, :DCAT, :EDM, :EXIF, :DOAP, :FOAF, :Fcrepo4, :GEOJSON, :GEO, :GR, :GEONAMES, :HYDRA, :IANA]
irb(main):008:0> RDF::Vocab::GEONAMES
NameError: uninitialized constant RDF::Vocab::GEONAMES
        from (irb):8
```