### PR TITLE
fixing missing class in ebucore

### DIFF
--- a/lib/rdf/vocab.rb
+++ b/lib/rdf/vocab.rb
@@ -104,7 +104,15 @@ module RDF
       ebucore: {
         uri: "http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#",
         source: "https://www.ebu.ch/metadata/ontologies/ebucore/ebucore.rdf",
-        class_name: "EBUCore"
+        class_name: "EBUCore",
+        patch: %{
+          @prefix owl: <http://www.w3.org/2002/07/owl#>.
+          @prefix dc: <http://purl.org/dc/terms/> .
+          @prefix dc11: <http://purl.org/dc/elements/1.1/> .
+          @prefix ebucore: <http://www.ebu.ch/metadata/ontologies/ebucore/ebucore#> .
+          DeleteExisting { ebucore:Agent owl:equivalentClass dc11:Agent . } .
+          AddNew { ebucore:Agent owl:equivalentClass dc:Agent . } .
+        },
       },
       edm: {
         uri: "http://www.europeana.eu/schemas/edm/",

--- a/lib/rdf/vocab/ebucore.rb
+++ b/lib/rdf/vocab/ebucore.rb
@@ -49,7 +49,7 @@ module RDF::Vocab
       type: "http://www.w3.org/2000/01/rdf-schema#Class".freeze
     term :Agent,
       comment: "A person / contact or organisation.".freeze,
-      equivalentClass: ["http://purl.org/dc/elements/1.1/Agent".freeze, "http://xmlns.com/foaf/0.1/Agent".freeze],
+      equivalentClass: ["http://purl.org/dc/terms/Agent".freeze, "http://xmlns.com/foaf/0.1/Agent".freeze],
       label: "Agent".freeze,
       subClassOf: "http://www.w3.org/2002/07/owl#Thing".freeze,
       type: "http://www.w3.org/2000/01/rdf-schema#Class".freeze


### PR DESCRIPTION
Noticed a crash scenario with EBUCore referencing `dc11:Agent` which doesn't exist. Fixing.